### PR TITLE
forcing git pull after reset

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT_VERSION="1.10.3"
+SCRIPT_VERSION="1.10.4"
 SCRIPT_NAME="Script Installer"
 
 SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -105,6 +105,7 @@ auto-update()
     echo "" 
     echo -e "${CYAN}New version found, updating...$NC"
     git -C $BASE_PATH reset --hard origin/$CURRENT_BRANCH
+    git pull
     echo "Update completed." 
 
     if [ $1 = true ]; 


### PR DESCRIPTION
Running `git pull` after `git reset` will ensure that the update has been performed properly.